### PR TITLE
Fix CRA build on Netlify

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -24,7 +24,7 @@
   },
   "scripts": {
     "start": "react-scripts --openssl-legacy-provider start",
-    "build": "react-scripts build",
+    "build": "react-scripts --openssl-legacy-provider build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },


### PR DESCRIPTION
## Summary
- ensure create-react-app build passes on Node 17+ by enabling the OpenSSL legacy provider

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872229cc980832ca5b77e4c20273b1b